### PR TITLE
Fix the submit dispatches

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -40,8 +40,10 @@ export default ({ optOutUrl }: OptOutUrl) => {
       switch (err) {
         case Result.invalid:
           dispatch('invalid')
+          break
         case Result.blocked:
           dispatch('blocked')
+          break
       }
       return
     }


### PR DESCRIPTION
<img width="1008" alt="Screen Shot 2020-01-07 at 5 01 26 AM" src="https://user-images.githubusercontent.com/5278201/71897225-c43d3100-310a-11ea-953b-41c197fb228c.png">


`Result.invalid` 와 `Result.blocked`는 명백히 다른데, 

break 문을 안 걸면 아래까지 내려와 `dispatch('blocked')`를 실행하게 됩니다.

왜 그런지는 이유를 모르겠네요 :/