### PR TITLE
Update to New Squaremorphism UI

### DIFF
--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -2,7 +2,12 @@ import { h, JSX } from 'preact'
 import { User, Lock, Eye, EyeOff } from 'preact-feather'
 
 import { Input as OriginalInput } from '../../styles/components/Input'
-import { darken_ultra, darken_medium, invaild } from '../../styles/colors'
+import {
+  darken_ultra,
+  darken_medium,
+  invaild,
+  white,
+} from '../../styles/colors'
 import { css, cx } from 'linaria'
 import { styled } from 'linaria/react'
 import { useState } from 'preact/hooks'
@@ -13,10 +18,10 @@ const LoginOutside = styled.div<IsWrong & JSX.HTMLAttributes<HTMLDivElement>>`
   padding-top: 5px;
   padding-bottom: 5px;
   background-color: ${darken_ultra};
-  box-shadow: 0 0 0 2px ${props => (props.isWrong ? invaild.outside : '')};
-  border: solid 1px ${props => (props.isWrong ? invaild.inside : 'transparent')};
-  transition: ${props => (props.isWrong ? 'border 0.5s' : '')};
-  transition: ${props => (props.isWrong ? 'box-shadow 0.5s' : '')};
+  box-shadow: inset 2px 2px 12px
+      ${props => (props.isWrong ? invaild.inside : '#dadeeb')},
+    inset -5px -5px 8px ${props => (props.isWrong ? invaild.outside : white)};
+  transition: box-shadow 0.2s ease-in-out;
 `
 
 const Icon = css`

--- a/src/app/components/Submit.tsx
+++ b/src/app/components/Submit.tsx
@@ -13,6 +13,11 @@ const SubmitButton = styled.button`
   cursor: pointer;
   width: 178px;
   align-self: center;
+  box-shadow: 0 10px 24px 0 ${primary};
+  transition: box-shadow 0.2s ease-in-out;
+  :hover {
+    box-shadow: 0 3px 10px 0 ${primary};
+  }
 `
 
 const Text = styled.span`


### PR DESCRIPTION
| `Result.idle` | `Result.invalid` | `button:hover` |
| :--: | :--: | :--: |
| ![Screen Shot 2020-05-11 at 12 20 06](https://user-images.githubusercontent.com/5278201/81521578-9ac73700-9382-11ea-9ea7-b672b5db2bd2.png) | ![Screen Shot 2020-05-11 at 12 20 26](https://user-images.githubusercontent.com/5278201/81521589-a0bd1800-9382-11ea-88b3-527b583b358b.png) |  <img width="265" alt="Screen Shot 2020-05-11 at 12 21 04 PM" src="https://user-images.githubusercontent.com/5278201/81521939-bc74ee00-9383-11ea-8813-681fbafa1ca2.png"> |

## WIP

- 입력 박스에 초점을 맞출 시 더 깊은 그림자로 교체하기