### PR TITLE
Fix Result handling

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -38,9 +38,23 @@ export default function App({ optOutUrl }: OptOutUrl) {
   const handleSubmit = async (e: SubmitEvent) => {
     e.preventDefault()
     dispatch(submitCreator(e.target))
-    if (result === Result.invalid || result === Result.blocked) return
-
     if (isKeepLogin) saveAccountInfo(getElementValues(e.target))
+  }
+
+  useEffect(() => {
+    setKeepLogin(isKeepLogin)
+    submitWhenKeepLogin()
+  }, [isKeepLogin])
+
+  useEffect(() => {
+    if (
+      result === Result.idle ||
+      result === Result.invalid ||
+      result === Result.blocked
+    ) {
+      // prettier-ignore
+      return
+    }
 
     if (result === Result.correct) {
       location.href = 'main.do'
@@ -52,13 +66,10 @@ export default function App({ optOutUrl }: OptOutUrl) {
       return
     }
 
-    throw Error('Unexpect state flow in handleSubmit')
-  }
-
-  useEffect(() => {
-    setKeepLogin(isKeepLogin)
-    submitWhenKeepLogin()
-  }, [isKeepLogin])
+    throw Error(
+      `Unexpect result flow in handleSubmit' current value: ${Result[result]}`
+    )
+  }, [result])
 
   const onChange = () => {
     if (isWrong) dispatch(IDLE)

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -38,12 +38,21 @@ export default function App({ optOutUrl }: OptOutUrl) {
   const handleSubmit = async (e: SubmitEvent) => {
     e.preventDefault()
     dispatch(submitCreator(e.target))
+    if (result === Result.invalid || result === Result.blocked) return
+
+    if (isKeepLogin) saveAccountInfo(getElementValues(e.target))
+
     if (result === Result.correct) {
-      if (isKeepLogin) {
-        saveAccountInfo(getElementValues(e.target))
-      }
       location.href = 'main.do'
+      return
     }
+
+    if (result === Result.changePassword) {
+      location.href = 'sysUserPwd.do?changepw=y'
+      return
+    }
+
+    throw Error('Unexpect state flow in handleSubmit')
   }
 
   useEffect(() => {

--- a/src/app/features/login.common.ts
+++ b/src/app/features/login.common.ts
@@ -30,6 +30,7 @@ export enum Result {
   'correct',
   'invalid',
   'blocked',
+  'changePassword',
 }
 
 export interface TargetElements extends EventTarget {

--- a/src/app/features/login.ts
+++ b/src/app/features/login.ts
@@ -22,6 +22,7 @@ export const formSubmit: FormSubmit = async (input: FormData) => {
     const invaildMessage = dbError[0].slice(15, -1) as ErrorMessage
     return invaildMessage === Exceed ? Result.blocked : Result.invalid
   }
+  if (data.includes('하영Dreamy 비밀번호 변경')) return Result.changePassword
   return Result.correct
 }
 

--- a/src/app/features/login.ts
+++ b/src/app/features/login.ts
@@ -16,11 +16,10 @@ export const formSubmit: FormSubmit = async (input: FormData) => {
     { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
   )
 
-  if (data.includes('dbError')) {
-    const invaildMessage = data
-      .match(/var dbError = "(?:\.|(\\\")|[^\""\n])*"/)[0]
-      .slice(15, -1) as ErrorMessage
+  const dbError = data.match(/var dbError = "(?:\.|(\\\")|[^\""\n])*"/)
 
+  if (dbError !== null) {
+    const invaildMessage = dbError[0].slice(15, -1) as ErrorMessage
     return invaildMessage === Exceed ? Result.blocked : Result.invalid
   }
   return Result.correct


### PR DESCRIPTION
로그인 요청의 응답으로 dbError 문자열이 들어가지만, 기술한 정규식에 맞지 않은 유스 케이스를 찾았습니다.
아래 사진처럼 6개월마다 비밀번호 변경을 권장하는 페이지로 리다이렉션됩니다.

<img width="551" alt="Screen Shot 2020-07-23 at 12 05 49 PM" src="https://user-images.githubusercontent.com/5278201/88248645-e0867100-ccdc-11ea-86c8-f5b2ec85acd9.png">

## 구현 할 항목

- [ ]  옵트-인 형태의 비밀번호 변경 페이지 이동 구현
- [ ] 위의 기능을 비활성화 할 웹 확장 설정 페이지 만들기