### PR TITLE
Use button instead anchor element

### DIFF
--- a/src/app/components/Label.tsx
+++ b/src/app/components/Label.tsx
@@ -1,9 +1,8 @@
 import { h } from 'preact'
 
-import { red } from '../../styles/colors'
+import { red, primary } from '../../styles/colors'
 import { Regular } from '../../styles/components/Text'
 import { styled } from 'linaria/react'
-import { Link } from './Link'
 
 interface WarningLabelProp {
   isBlocked: boolean
@@ -25,6 +24,15 @@ const CenterLabel = styled(Label)`
   margin-top: 16px;
 `
 
+const TextButton = styled.button`
+  color: ${primary};
+  font-weight: bold;
+  padding: 0;
+  background-color: transparent;
+  font-size: 1em;
+  cursor: pointer;
+`
+
 export const WarningLabel = ({ isBlocked }: WarningLabelProp) => (
   <RedLabel isBlocked={isBlocked}>너무 많이 로그인을 시도하였습니다</RedLabel>
 )
@@ -35,6 +43,6 @@ const openFindPassword = () => {
 
 export const FindPassword = () => (
   <CenterLabel>
-    또는 <Link onClick={openFindPassword}>비밀번호 찾기</Link>
+    또는 <TextButton onClick={openFindPassword}>비밀번호 찾기</TextButton>
   </CenterLabel>
 )

--- a/src/app/components/Link.tsx
+++ b/src/app/components/Link.tsx
@@ -1,9 +1,0 @@
-import { styled } from 'linaria/react'
-
-import { primary } from '../../styles/colors'
-
-export const Link = styled.a`
-  color: ${primary};
-  font-weight: bold;
-  cursor: pointer;
-`


### PR DESCRIPTION
<blockquote class="twitter-tweet"><p lang="ko" dir="ltr">웹 접근성 문제로 버튼 엘리먼트 대용으로 링크 태그를 쓰지 않았으면 좋습니다. 회원가입 폼을 키보드로 조작하며 두번이나 마우스에 손을 대서 불편했네요. <a href="https://twitter.com/booknlife?ref_src=twsrc%5Etfw">@booknlife</a> <a href="https://t.co/6p2XfFRwhv">pic.twitter.com/6p2XfFRwhv</a></p>&mdash; 팔육칩 (@x86chi) <a href="https://twitter.com/x86chi/status/1318499782332067840?ref_src=twsrc%5Etfw">October 20, 2020</a></blockquote>

😅 